### PR TITLE
Try to enhance string deserialization

### DIFF
--- a/src/jmh/java/com/imprint/benchmark/StringBenchmark.java
+++ b/src/jmh/java/com/imprint/benchmark/StringBenchmark.java
@@ -44,6 +44,10 @@ public class StringBenchmark {
     private byte[] serializedLarge10K;
     private byte[] serializedLarge100K;
     private byte[] serializedLarge1M;
+
+    private ImprintRecord preDeserializedSmall5;
+    private ImprintRecord preDeserializedMedium500;
+    private ImprintRecord preDeserializedLarge100K;
     
     @Setup
     public void setup() throws Exception {
@@ -66,6 +70,10 @@ public class StringBenchmark {
         serializedLarge10K = bufferToArray(createStringRecord(largeString10K).serializeToBuffer());
         serializedLarge100K = bufferToArray(createStringRecord(largeString100K).serializeToBuffer());
         serializedLarge1M = bufferToArray(createStringRecord(largeString1M).serializeToBuffer());
+
+        preDeserializedSmall5 = ImprintRecord.deserialize(serializedSmall5);
+        preDeserializedMedium500 = ImprintRecord.deserialize(serializedMedium500);
+        preDeserializedLarge100K = ImprintRecord.deserialize(serializedLarge100K);
     }
     
     private String generateString(int length) {
@@ -237,6 +245,30 @@ public class StringBenchmark {
     @Benchmark
     public int measureLargeString100KSize() throws Exception {
         return createStringRecord(largeString100K).serializeToBuffer().remaining();
+    }
+
+    // Pure string access benchmarks (no record deserialization overhead)
+    @Benchmark
+    public String pureStringAccessSmall5() throws Exception {
+        return preDeserializedSmall5.getValue(1).map(this::extractString).orElse(null);
+    }
+
+    @Benchmark
+    public String pureStringAccessMedium500() throws Exception {
+        return preDeserializedMedium500.getValue(1).map(this::extractString).orElse(null);
+    }
+
+    @Benchmark
+    public String pureStringAccessLarge100K() throws Exception {
+        return preDeserializedLarge100K.getValue(1).map(this::extractString).orElse(null);
+    }
+
+    // Test cached vs uncached access
+    @Benchmark
+    public String cachedStringAccessSmall5() throws Exception {
+        // Second access should hit cache
+        preDeserializedSmall5.getValue(1).map(this::extractString).orElse(null);
+        return preDeserializedSmall5.getValue(1).map(this::extractString).orElse(null);
     }
     
     public static void main(String[] args) throws Exception {

--- a/src/main/java/com/imprint/core/ImprintRecord.java
+++ b/src/main/java/com/imprint/core/ImprintRecord.java
@@ -114,14 +114,14 @@ public final class ImprintRecord {
     }
     
     /**
-     * Deserialize a record from bytes.
+     * Deserialize a record from bytes through an array backed ByteBuffer.
      */
     public static ImprintRecord deserialize(byte[] bytes) throws ImprintException {
         return deserialize(ByteBuffer.wrap(bytes));
     }
     
     /**
-     * Deserialize a record from a ByteBuffer (zero-copy when possible).
+     * Deserialize a record from a ByteBuffer.
      */
     public static ImprintRecord deserialize(ByteBuffer buffer) throws ImprintException {
         buffer = buffer.duplicate().order(ByteOrder.LITTLE_ENDIAN);

--- a/src/main/java/com/imprint/types/TypeHandler.java
+++ b/src/main/java/com/imprint/types/TypeHandler.java
@@ -4,7 +4,6 @@ import com.imprint.error.ImprintException;
 import com.imprint.util.VarInt;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 
 /**
  * Interface for handling type-specific serialization, deserialization, and size estimation.
@@ -270,7 +269,7 @@ public interface TypeHandler {
                 buffer.put(stringBuffer);
             } else {
                 Value.StringValue stringValue = (Value.StringValue) value;
-                byte[] stringBytes = stringValue.getValue().getBytes(StandardCharsets.UTF_8);
+                byte[] stringBytes = stringValue.getUtf8Bytes(); // Use cached UTF-8 bytes
                 VarInt.encode(stringBytes.length, buffer);
                 buffer.put(stringBytes);
             }
@@ -283,9 +282,9 @@ public interface TypeHandler {
                 int length = bufferValue.getBuffer().remaining();
                 return VarInt.encodedLength(length) + length;
             } else {
-                String str = ((Value.StringValue) value).getValue();
-                int utf8Length = str.getBytes(StandardCharsets.UTF_8).length;
-                return VarInt.encodedLength(utf8Length) + utf8Length;
+                Value.StringValue stringValue = (Value.StringValue) value;
+                byte[] utf8Bytes = stringValue.getUtf8Bytes(); // Use cached UTF-8 bytes
+                return VarInt.encodedLength(utf8Bytes.length) + utf8Bytes.length;
             }
         }
         


### PR DESCRIPTION
- Added more benchmark tests for strings
- adding some clarifying comments
- remove locking on string values since UTF-8 is idempotent anyways
- split path for array and non-array based ByteBuffer in string buffer decode (ours are always array based which means we can use zero-copy strategies)